### PR TITLE
README: Document passing friendship to after callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,23 +91,25 @@ Popular provides callbacks that are fired around friendship creation. Available 
 ```ruby
 class User < ActiveRecord::Base
   popular
-  after_befriend :notify_friendship_created
-  after_unfriend :notify_unfriended
 
-  def notify_friendship_created
-    puts "Friendship created successfully"
+  # You can also use a symbol here but the friendship won't be passed to your method
+  after_befriend 'notify_friendship_created value'
+  after_unfriend 'notify_unfriended value'
+
+  def notify_friendship_created(friendship)
+    puts "#{name} friended #{friendship.friend.name}"
   end
 
-  def notify_unfriended
-    puts ":("
+  def notify_unfriended(friendship)
+    puts "#{name} unfriended #{friendship.friend.name}"
   end
 end
 
 @justin = User.create name: "Justin"
 @jenny = User.create name: "Jenny"
 
-@justin.befriend @jenny #=> "Friendship created successfully"
-@justin.unfriend @jenny #=> ":("
+@justin.befriend @jenny #=> "Justin friended Jenny"
+@justin.unfriend @jenny #=> "Justin unfriended Jenny"
 ```
 
 ### Customization

--- a/lib/popular/popular.rb
+++ b/lib/popular/popular.rb
@@ -158,10 +158,10 @@ module Popular
       #
       #   class User < ActiveRecord::Base
       #     popular
-      #     after_unfriend :do_something_amazing
+      #     after_unfriend 'do_something_amazing value'
       #
-      #     def do_something_amazing
-      #       puts name
+      #     def do_something_amazing(friendship)
+      #       puts "#{name} unfriended #{friendship.friend.name}"
       #     end
       #   end
       #
@@ -169,7 +169,7 @@ module Popular
       #   another_user = User.create name: "Jenny"
       #
       #   user.befriend another_user
-      #   user.unfriend another_user #=> "Justin"
+      #   user.unfriend another_user #=> "Justin unfriended Jenny"
       def after_unfriend *args, &blk
         set_callback :unfriend, :after, *args, &blk
       end
@@ -226,17 +226,17 @@ module Popular
       #
       #   class User < ActiveRecord::Base
       #     popular
-      #     after_befriend :do_something_amazing
+      #     after_befriend 'do_something_amazing value'
       #
-      #     def do_something_amazing
-      #       puts name
+      #     def do_something_amazing(friendship)
+      #       puts '#{name} friended #{friendship.friend.nanme}'
       #     end
       #   end
       #
       #   user = User.create name: "Justin"
       #   another_user = User.create name: "Jenny"
       #
-      #   user.befriend another_user #=> "Justin"
+      #   user.befriend another_user #=> "Justin friended Jenny"
       def after_befriend *args, &blk
         set_callback :befriend, :after, *args, &blk
       end


### PR DESCRIPTION
Documentation doesn't mention how to access the friend being followed/unfollowed from `after` callbacks. I document my adventures on how I discovered this [here](https://gist.github.com/ericboehs/ccc6b78349fc32e5f1bb).

By the way, the `value` is returned when creating the friendship. Therefore, `value` will be `nil` for before callbacks. This is because it is being called _before_ the friendship creation code is ever ran.

Also, inline code documentation should probably be updated too.
